### PR TITLE
add env.yaml file

### DIFF
--- a/conda/environment.yaml
+++ b/conda/environment.yaml
@@ -1,0 +1,20 @@
+name: sp 
+channels:
+  - conda-forge
+dependencies:
+  - python==3.12
+  - numpy<2
+  - scipy
+  - petsc4py==3.21.5
+  - mpi4py
+  - numpy<2
+  - h5py=*=mpi*
+  - pytest
+  - matplotlib
+  - jupyterlab
+  - jupytext
+  - pip 
+  - pip:
+    - lavavu
+    - k3d
+


### PR DESCRIPTION
Add the  environment.yaml 
(Installing the latest version of petsc4py using conda may cause Jupyter Lab to crash due to dependency conflicts. This issue can be resolved by installing an older version, such as 3.21.5)

Other Issues to Consider:
(1) saving dm to h5 file. This issue can be tested in the following Jupyter Notebook: [Ex1-Creating-Meshes](https://github.com/underworldcode/quagmire/blob/meson-build/jupyterbook/Tutorial/Ex1-Creating-Meshes.ipynb)
(2) Certain functions in Quagmire are not functioning correctly, including quagmire.function.misc.levelset() for surface process calculations. This issue can be tested in the following Jupyter Notebook: [Ex7-LinearDiffusion.ipynb](https://github.com/underworldcode/quagmire/blob/master/jupyterbook/Tutorial/Ex7-LinearDiffusion.ipynb)). We may need to revisit these functions.